### PR TITLE
Create country details page with shadcn

### DIFF
--- a/src/app/(app)/countries_details/[countryId]/CountryDetailsContent.tsx
+++ b/src/app/(app)/countries_details/[countryId]/CountryDetailsContent.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+import { Separator } from '@components/ui/separator';
+import QuickFactsSection from './components/QuickFactsSection';
+import FamousLandmarksSection from './components/FamousLandmarksSection';
+import NotablePeopleSection from './components/NotablePeopleSection';
+import FunFactsSection from './components/FunFactsSection';
+import FAQSection from './components/FAQSection';
+import MapSection from './components/MapSection';
+import SourcesSection from './components/SourcesSection';
+
+type Props = {
+  countryDetails: CountryDetailsRecord;
+};
+
+const CountryDetailsContent = ({ countryDetails }: Props) => {
+  return (
+    <div className='space-y-8'>
+      {/* Main Summary */}
+      {countryDetails.summary && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Overview</CardTitle>
+            <CardDescription>General information about the country</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className='leading-relaxed text-gray-700 dark:text-gray-300'>
+              {countryDetails.summary}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Capital Summary */}
+      {countryDetails.capital_summary && (
+        <Card>
+          <CardHeader>
+            <CardTitle>About the Capital</CardTitle>
+            <CardDescription>Information about the capital city</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className='leading-relaxed text-gray-700 dark:text-gray-300'>
+              {countryDetails.capital_summary}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Quick Facts */}
+      {countryDetails.quick_facts && (
+        <QuickFactsSection facts={countryDetails.quick_facts} />
+      )}
+
+      {/* Map */}
+      {countryDetails.map_embed_url && (
+        <MapSection mapUrl={countryDetails.map_embed_url} />
+      )}
+
+      {/* Famous Landmarks */}
+      {countryDetails.famous_landmarks && (
+        <FamousLandmarksSection landmarks={countryDetails.famous_landmarks} />
+      )}
+
+      {/* Notable People */}
+      {countryDetails.notable_people && (
+        <NotablePeopleSection people={countryDetails.notable_people} />
+      )}
+
+      {/* Fun Facts */}
+      {countryDetails.fun_facts && (
+        <FunFactsSection facts={countryDetails.fun_facts} />
+      )}
+
+      {/* FAQs */}
+      {countryDetails.faqs && (
+        <FAQSection faqs={countryDetails.faqs} />
+      )}
+
+      {/* Verification Status and Last Updated */}
+      <Card>
+        <CardContent className='pt-6'>
+          <div className='flex flex-col gap-2 text-sm text-gray-500 dark:text-gray-400'>
+            <div className='flex items-center justify-between'>
+              <span>Verification Status:</span>
+              <span
+                className={`rounded-full px-2 py-1 text-xs font-medium ${
+                  countryDetails.is_verified
+                    ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                    : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                }`}
+              >
+                {countryDetails.is_verified ? 'Verified' : 'Pending Review'}
+              </span>
+            </div>
+            {countryDetails.last_updated && (
+              <div className='flex items-center justify-between'>
+                <span>Last Updated:</span>
+                <span>
+                  {new Date(countryDetails.last_updated).toLocaleDateString()}
+                </span>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Sources */}
+      {countryDetails.sources && (
+        <SourcesSection sources={countryDetails.sources} />
+      )}
+    </div>
+  );
+};
+
+export default CountryDetailsContent;

--- a/src/app/(app)/countries_details/[countryId]/components/FAQSection.tsx
+++ b/src/app/(app)/countries_details/[countryId]/components/FAQSection.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+
+type FAQ = {
+  question: string;
+  answer: string;
+  category?: string;
+};
+
+type Props = {
+  faqs: any; // JSON data
+};
+
+const FAQSection = ({ faqs }: Props) => {
+  let parsedFAQs: FAQ[] = [];
+  
+  try {
+    if (typeof faqs === 'string') {
+      parsedFAQs = JSON.parse(faqs);
+    } else if (Array.isArray(faqs)) {
+      parsedFAQs = faqs;
+    }
+  } catch (error) {
+    console.error('Error parsing FAQs:', error);
+    return null;
+  }
+
+  if (!parsedFAQs.length) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Frequently Asked Questions</CardTitle>
+        <CardDescription>Common questions and answers</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-4'>
+          {parsedFAQs.map((faq, index) => (
+            <details
+              key={index}
+              className='group rounded-lg border border-gray-200 dark:border-gray-700'
+            >
+              <summary className='flex cursor-pointer items-center justify-between p-4 font-medium text-gray-900 hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-800'>
+                <div className='flex-1'>
+                  {faq.category && (
+                    <span className='mb-1 inline-block rounded-full bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200'>
+                      {faq.category}
+                    </span>
+                  )}
+                  <p className='text-left'>{faq.question}</p>
+                </div>
+                <span className='ml-4 transform transition-transform duration-200 group-open:rotate-180'>
+                  ▼
+                </span>
+              </summary>
+              <div className='border-t border-gray-200 p-4 dark:border-gray-700'>
+                <p className='leading-relaxed text-gray-700 dark:text-gray-300'>
+                  {faq.answer}
+                </p>
+              </div>
+            </details>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FAQSection;

--- a/src/app/(app)/countries_details/[countryId]/components/FamousLandmarksSection.tsx
+++ b/src/app/(app)/countries_details/[countryId]/components/FamousLandmarksSection.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+
+type Landmark = {
+  name: string;
+  description: string;
+  location?: string;
+  year_built?: string | number;
+  significance?: string;
+};
+
+type Props = {
+  landmarks: any; // JSON data
+};
+
+const FamousLandmarksSection = ({ landmarks }: Props) => {
+  let parsedLandmarks: Landmark[] = [];
+  
+  try {
+    if (typeof landmarks === 'string') {
+      parsedLandmarks = JSON.parse(landmarks);
+    } else if (Array.isArray(landmarks)) {
+      parsedLandmarks = landmarks;
+    }
+  } catch (error) {
+    console.error('Error parsing landmarks:', error);
+    return null;
+  }
+
+  if (!parsedLandmarks.length) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Famous Landmarks</CardTitle>
+        <CardDescription>Notable places and monuments</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-6'>
+          {parsedLandmarks.map((landmark, index) => (
+            <div
+              key={index}
+              className='rounded-lg border border-gray-200 p-4 dark:border-gray-700'
+            >
+              <h4 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
+                {landmark.name}
+              </h4>
+              {landmark.location && (
+                <p className='mt-1 text-sm text-gray-500 dark:text-gray-400'>
+                  📍 {landmark.location}
+                </p>
+              )}
+              {landmark.year_built && (
+                <p className='mt-1 text-sm text-gray-500 dark:text-gray-400'>
+                  🏗️ Built: {landmark.year_built}
+                </p>
+              )}
+              <p className='mt-2 leading-relaxed text-gray-700 dark:text-gray-300'>
+                {landmark.description}
+              </p>
+              {landmark.significance && (
+                <div className='mt-3 rounded bg-blue-50 p-3 dark:bg-blue-900/20'>
+                  <p className='text-sm text-blue-800 dark:text-blue-200'>
+                    <strong>Significance:</strong> {landmark.significance}
+                  </p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FamousLandmarksSection;

--- a/src/app/(app)/countries_details/[countryId]/components/FunFactsSection.tsx
+++ b/src/app/(app)/countries_details/[countryId]/components/FunFactsSection.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+
+type FunFact = {
+  fact: string;
+  category?: string;
+};
+
+type Props = {
+  facts: any; // JSON data
+};
+
+const FunFactsSection = ({ facts }: Props) => {
+  let parsedFacts: (FunFact | string)[] = [];
+  
+  try {
+    if (typeof facts === 'string') {
+      parsedFacts = JSON.parse(facts);
+    } else if (Array.isArray(facts)) {
+      parsedFacts = facts;
+    }
+  } catch (error) {
+    console.error('Error parsing fun facts:', error);
+    return null;
+  }
+
+  if (!parsedFacts.length) return null;
+
+  const getRandomEmoji = () => {
+    const emojis = ['🤔', '💡', '🎯', '⭐', '🌟', '✨', '🎪', '🎭', '🎨', '🎲'];
+    return emojis[Math.floor(Math.random() * emojis.length)];
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Fun Facts</CardTitle>
+        <CardDescription>Interesting and surprising facts</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-4'>
+          {parsedFacts.map((item, index) => {
+            const fact = typeof item === 'string' ? item : item.fact;
+            const category = typeof item === 'object' && item.category ? item.category : null;
+            
+            return (
+              <div
+                key={index}
+                className='flex gap-3 rounded-lg bg-gradient-to-r from-purple-50 to-pink-50 p-4 dark:from-purple-900/20 dark:to-pink-900/20'
+              >
+                <span className='text-xl'>{getRandomEmoji()}</span>
+                <div className='flex-1'>
+                  {category && (
+                    <span className='mb-1 inline-block rounded-full bg-purple-100 px-2 py-1 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-200'>
+                      {category}
+                    </span>
+                  )}
+                  <p className='leading-relaxed text-gray-700 dark:text-gray-300'>
+                    {fact}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FunFactsSection;

--- a/src/app/(app)/countries_details/[countryId]/components/MapSection.tsx
+++ b/src/app/(app)/countries_details/[countryId]/components/MapSection.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+
+type Props = {
+  mapUrl: string;
+};
+
+const MapSection = ({ mapUrl }: Props) => {
+  if (!mapUrl) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Location Map</CardTitle>
+        <CardDescription>Geographic location and surroundings</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='relative overflow-hidden rounded-lg'>
+          <iframe
+            src={mapUrl}
+            width='100%'
+            height='400'
+            style={{ border: 0 }}
+            allowFullScreen
+            loading='lazy'
+            referrerPolicy='no-referrer-when-downgrade'
+            className='rounded-lg'
+            title='Country Location Map'
+          />
+        </div>
+        <p className='mt-2 text-xs text-gray-500 dark:text-gray-400'>
+          Interactive map showing the country's location and geographic features
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MapSection;

--- a/src/app/(app)/countries_details/[countryId]/components/NotablePeopleSection.tsx
+++ b/src/app/(app)/countries_details/[countryId]/components/NotablePeopleSection.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+
+type NotablePerson = {
+  name: string;
+  description: string;
+  field?: string;
+  birth_year?: string | number;
+  death_year?: string | number;
+  achievements?: string;
+};
+
+type Props = {
+  people: any; // JSON data
+};
+
+const NotablePeopleSection = ({ people }: Props) => {
+  let parsedPeople: NotablePerson[] = [];
+  
+  try {
+    if (typeof people === 'string') {
+      parsedPeople = JSON.parse(people);
+    } else if (Array.isArray(people)) {
+      parsedPeople = people;
+    }
+  } catch (error) {
+    console.error('Error parsing notable people:', error);
+    return null;
+  }
+
+  if (!parsedPeople.length) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Notable People</CardTitle>
+        <CardDescription>Famous individuals from this country</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='grid gap-4 md:grid-cols-2'>
+          {parsedPeople.map((person, index) => (
+            <div
+              key={index}
+              className='rounded-lg border border-gray-200 p-4 dark:border-gray-700'
+            >
+              <h4 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
+                {person.name}
+              </h4>
+              {person.field && (
+                <p className='mt-1 text-sm font-medium text-blue-600 dark:text-blue-400'>
+                  {person.field}
+                </p>
+              )}
+              {(person.birth_year || person.death_year) && (
+                <p className='mt-1 text-sm text-gray-500 dark:text-gray-400'>
+                  {person.birth_year && `Born: ${person.birth_year}`}
+                  {person.birth_year && person.death_year && ' • '}
+                  {person.death_year && `Died: ${person.death_year}`}
+                </p>
+              )}
+              <p className='mt-2 text-sm leading-relaxed text-gray-700 dark:text-gray-300'>
+                {person.description}
+              </p>
+              {person.achievements && (
+                <div className='mt-3 rounded bg-green-50 p-3 dark:bg-green-900/20'>
+                  <p className='text-sm text-green-800 dark:text-green-200'>
+                    <strong>Key Achievements:</strong> {person.achievements}
+                  </p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default NotablePeopleSection;

--- a/src/app/(app)/countries_details/[countryId]/components/QuickFactsSection.tsx
+++ b/src/app/(app)/countries_details/[countryId]/components/QuickFactsSection.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+
+type QuickFact = {
+  label: string;
+  value: string;
+};
+
+type Props = {
+  facts: any; // JSON data
+};
+
+const QuickFactsSection = ({ facts }: Props) => {
+  let parsedFacts: QuickFact[] = [];
+  
+  try {
+    // Handle different possible JSON structures
+    if (typeof facts === 'string') {
+      parsedFacts = JSON.parse(facts);
+    } else if (Array.isArray(facts)) {
+      parsedFacts = facts;
+    } else if (typeof facts === 'object' && facts !== null) {
+      // Convert object to array of key-value pairs
+      parsedFacts = Object.entries(facts).map(([key, value]) => ({
+        label: key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()),
+        value: String(value),
+      }));
+    }
+  } catch (error) {
+    console.error('Error parsing quick facts:', error);
+    return null;
+  }
+
+  if (!parsedFacts.length) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Quick Facts</CardTitle>
+        <CardDescription>Key information at a glance</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+          {parsedFacts.map((fact, index) => (
+            <div
+              key={index}
+              className='rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800'
+            >
+              <dt className='text-sm font-medium text-gray-500 dark:text-gray-400'>
+                {fact.label}
+              </dt>
+              <dd className='mt-1 text-sm font-semibold text-gray-900 dark:text-gray-100'>
+                {fact.value}
+              </dd>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default QuickFactsSection;

--- a/src/app/(app)/countries_details/[countryId]/components/SourcesSection.tsx
+++ b/src/app/(app)/countries_details/[countryId]/components/SourcesSection.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardContent,
+  CardDescription,
+} from '@components/ui/card';
+
+type Source = {
+  title: string;
+  url?: string;
+  author?: string;
+  date?: string;
+  description?: string;
+};
+
+type Props = {
+  sources: any; // JSON data
+};
+
+const SourcesSection = ({ sources }: Props) => {
+  let parsedSources: (Source | string)[] = [];
+  
+  try {
+    if (typeof sources === 'string') {
+      parsedSources = JSON.parse(sources);
+    } else if (Array.isArray(sources)) {
+      parsedSources = sources;
+    }
+  } catch (error) {
+    console.error('Error parsing sources:', error);
+    return null;
+  }
+
+  if (!parsedSources.length) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sources & References</CardTitle>
+        <CardDescription>Information sources used for this content</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-3'>
+          {parsedSources.map((item, index) => {
+            if (typeof item === 'string') {
+              return (
+                <div
+                  key={index}
+                  className='rounded border-l-4 border-blue-500 bg-blue-50 p-3 dark:bg-blue-900/20'
+                >
+                  <p className='text-sm text-gray-700 dark:text-gray-300'>{item}</p>
+                </div>
+              );
+            }
+
+            const source = item as Source;
+            return (
+              <div
+                key={index}
+                className='rounded border-l-4 border-blue-500 bg-blue-50 p-3 dark:bg-blue-900/20'
+              >
+                {source.url ? (
+                  <a
+                    href={source.url}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='text-sm font-medium text-blue-700 hover:text-blue-900 dark:text-blue-300 dark:hover:text-blue-100'
+                  >
+                    {source.title}
+                  </a>
+                ) : (
+                  <p className='text-sm font-medium text-gray-900 dark:text-gray-100'>
+                    {source.title}
+                  </p>
+                )}
+                {source.author && (
+                  <p className='mt-1 text-xs text-gray-600 dark:text-gray-400'>
+                    By: {source.author}
+                  </p>
+                )}
+                {source.date && (
+                  <p className='text-xs text-gray-600 dark:text-gray-400'>
+                    {source.date}
+                  </p>
+                )}
+                {source.description && (
+                  <p className='mt-1 text-xs text-gray-700 dark:text-gray-300'>
+                    {source.description}
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default SourcesSection;

--- a/src/app/(app)/countries_details/[countryId]/page.tsx
+++ b/src/app/(app)/countries_details/[countryId]/page.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { getCountryById } from '@server/db/countries-rest';
+import { getCountryDetailsById } from '@server/db/countries-details-rest';
+import { getCountryStatsById } from '@server/db/countries-stats-rest';
+import CountryDescription from '@features/quiz/components/CountryDescription';
+import CountryShape from '@features/quiz/components/CountryShape';
+import { navigationLinks } from '@lib/data/navigation-links';
+import { supabase } from '@lib/supabase/static';
+import PageCenteredLink from '@components/global/PageCenteredLink';
+import CountryDetailsContent from './CountryDetailsContent';
+
+type Props = {
+  params: Promise<{ countryId: number }>;
+};
+
+export const revalidate = 86400; // 1 day
+export const dynamic = 'force-static';
+
+export async function generateMetadata(props: Props) {
+  const params = await props.params;
+  const { countryId } = params;
+  const { name } = await getCountryById(countryId);
+
+  return {
+    title: `${name} - Detailed Information`,
+    description: `Comprehensive information about ${name} including landmarks, culture, facts, and more.`,
+  };
+}
+
+export async function generateStaticParams() {
+  // fetching from default supabase client cause cant work with cookies at build time
+  const { data } = await supabase.from('countries').select('id');
+  if (!data) {
+    return [];
+  }
+
+  return data.map((country) => ({
+    countryId: country.id.toString(),
+  }));
+}
+
+const CountryDetailsPage = async (props: Props) => {
+  const params = await props.params;
+  const [country, countryStats, countryDetails] = await Promise.all([
+    getCountryById(params.countryId),
+    getCountryStatsById(params.countryId),
+    getCountryDetailsById(params.countryId),
+  ]);
+
+  if (!countryDetails) {
+    return (
+      <div className='mx-auto flex max-w-4xl flex-col gap-8 px-4 py-8'>
+        <CountryDescription countryData={country} countryStats={countryStats} />
+        <div className='rounded-lg bg-gray-50 p-8 text-center dark:bg-gray-900'>
+          <h2 className='text-xl font-semibold text-gray-600 dark:text-gray-400'>
+            Detailed information for {country.name} is not available yet.
+          </h2>
+          <p className='mt-2 text-gray-500 dark:text-gray-500'>
+            We're working on adding comprehensive details for all countries.
+          </p>
+        </div>
+        <PageCenteredLink
+          href={navigationLinks.countries.href}
+          label='All Countries'
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className='mx-auto flex max-w-4xl flex-col gap-8 px-4 py-8'>
+      <CountryDescription countryData={country} countryStats={countryStats} />
+      <CountryShape countryCode={country.iso2} />
+      <CountryDetailsContent countryDetails={countryDetails} />
+      <PageCenteredLink
+        href={navigationLinks.countries.href}
+        label='All Countries'
+      />
+    </div>
+  );
+};
+
+export default CountryDetailsPage;

--- a/src/lib/types/global.d.ts
+++ b/src/lib/types/global.d.ts
@@ -119,6 +119,14 @@ declare global {
   type UserGuessHistoryUpdate =
     Database['public']['Tables']['user_guesses_history']['Update'];
 
+  // Aliases for 'country_details' table
+  type CountryDetailsRecord =
+    Database['public']['Tables']['country_details']['Row'];
+  type CountryDetailsInsert =
+    Database['public']['Tables']['country_details']['Insert'];
+  type CountryDetailsUpdate =
+    Database['public']['Tables']['country_details']['Update'];
+
   // Aliases for 'countries_complete_view' view
   type CountryCompleteViewRecordOriginal =
     Database['public']['Views']['countries_complete_view']['Row'];

--- a/src/shared/server/db/countries-details-rest.ts
+++ b/src/shared/server/db/countries-details-rest.ts
@@ -1,0 +1,23 @@
+const baseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL + '/rest/v1';
+const ONE_HOUR = 3600;
+
+export async function getCountryDetailsById(countryId: CountryRecord['id']) {
+  const url = `${baseUrl}/country_details?country_id=eq.${countryId}&select=*`;
+
+  const res: Response = await fetch(url, {
+    headers: {
+      apiKey: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      'Content-Type': 'application/json',
+    },
+    next: { revalidate: ONE_HOUR },
+  });
+
+  if (!res.ok) {
+    console.error('Error fetching country details by id:', res.statusText);
+    throw new Error('Failed to fetch country details by id');
+  }
+
+  const data = await res.json();
+
+  return (data[0] as CountryDetailsRecord) || null;
+}


### PR DESCRIPTION
Add a new `/countries_details/{countryId}` page to display comprehensive country details from the `country_details` database.

---

[Open in Web](https://cursor.com/agents?id=bc-dc4cfa92-fb00-4d74-8a78-b2c19b5639aa) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-dc4cfa92-fb00-4d74-8a78-b2c19b5639aa) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)